### PR TITLE
added safety lines to get_concordant_answer()

### DIFF
--- a/src/run_evaluation.py
+++ b/src/run_evaluation.py
@@ -16,7 +16,7 @@ def eval_gsm_svamp(df):
             return False 
     v_diff = np.vectorize(diff_if_possible)
     corrects = v_diff(df.majority_ans, df.answer).sum()
-    return corrects
+    return corrects if len(df)>0 else 0
 
 
 def eval_math(df):
@@ -29,7 +29,7 @@ def eval_math(df):
         axis=1,
     )
 
-    return equiv_flag.sum()
+    return equiv_flag.sum() if len(df)>0 else 0
 
 def eval_ocw(df):
     df["submission"] = df.majority_ans.astype("str")
@@ -41,7 +41,7 @@ def eval_ocw(df):
         axis=1,
     )
 
-    return equiv_flag.sum()
+    return equiv_flag.sum() if len(df)>0 else 0
 
 
 def main(eval_jslf: str, eval_type: str = Literal["gsm", "math"]):

--- a/src/utils/llm_query_utils.py
+++ b/src/utils/llm_query_utils.py
@@ -1121,8 +1121,8 @@ def get_concordant_answer(
             return majority if isinstance(majority, float) else None
         else:
             return None
-        
-    answers_no_none = [a for a in answers if a is not None]
+
+    answers_no_none = [a for a in answers if (a is not None and a != "None")]
     
     if dataset_type in ["svamp", "gsm"]:
         majority, count = Counter(answers_no_none).most_common(1)[0]


### PR DESCRIPTION
prevent wrong processing of "None"

get_concordant_answer() 에 "None" (스트링) 이 들어가는 경우는 dd4c82a (_convert_to_str_if_not_none_nor_float() [permalink](https://github.com/fgenie/rims_minimal/blob/a32c9e17849724de8f5a4e81097a01d4a4331e2c/src/utils/llm_query_utils.py#L1029)) 이후 해결되었으나, 지금 나와같이 그것보다 이전 코드의 아웃풋을 재사용하는 경우 발생할 수 있는 케이스에 대한 추가처리 로직을 추가


MATH chatgpt 결과에서만 이 문제가 보여길래 찾아봤더니 이랬다 

해당 수정 후에 #20 의 마지막 수정 결과와 같은 점수가 나오는 것을 통해서 검증됨.
