### PR TITLE
Added + validated is_equiv_ocw() and its related functions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ python run_inference.py  rims_inference  \
 
 ### 3 evaluate
 ```bash
-# baseline result
-python run_evaluation.py --eval_jslf dbgoutdir/chatgpt_01_18_04_48_model_selection3_startidx0.jsonl
-# rims result
-python run_evaluation.py --eval_jslf dbgoutdir/chatgpt_rims_01_18_04_49_startidx0.jsonl
+# baseline/rims result
+python run_evaluation.py --eval_jslf dbgoutdir/chatgpt_rims_01_18_04_49_startidx0.jsonl --eval_type [gsm|svamp|ocw|math]
+# individual method (i.e. cot, pal, p2c) results
+python run_evaluation_each.py --eval_jslf dbgoutdir/chatgpt_rims_01_18_04_49_startidx0.jsonl --eval_type [gsm|svamp|ocw|math]
 ```
 
 
-## todo
- - add
-    - [x] `NameError` when running baseline_inference on MATH dataset?
-    - [ ] ocw, (math) symbolic including prompts
+## todo candids
+ - prompts with symbolic examples (math ocw)
+ - openLLM experiments
+ - analyses on the results so far
 
 ## algorithm
 TBA

--- a/src/utils/llm_query_utils.py
+++ b/src/utils/llm_query_utils.py
@@ -1179,29 +1179,28 @@ def get_concordant_answer(
                         return revert_normalized[a1]
                 return None  # no concordant answers
     elif dataset_type in ["ocw"]:
-        answers_normalized = [
-            math_util.normalize_final_answer(str(a)) for a in answers_no_none
-        ]
         if ensure_unanimity:
+            answers_normalized = [
+                math_util.normalize_final_answer(str(a)) for a in answers_no_none
+            ]
             if len(set(answers_normalized)) == 1:
                 return answers_no_none.pop()
             else:
                 return None
         else:
-            if len(answers_normalized) == 0:
+            if len(answers_no_none) == 0:
                 return None
-            elif len(answers_normalized) == 1:
+            elif len(answers_no_none) == 1:
                 return answers_no_none.pop()
-            elif len(answers_normalized) == 2:
-                if math_util.is_equiv_ocw(answers_normalized[0], answers_normalized[1]):
+            elif len(answers_no_none) == 2:
+                if math_util.is_equiv_ocw(answers_no_none[0], answers_no_none[1]):
                     return answers_no_none[0]
                 else:
                     return None
             else:  # len()==3
-                revert_normalized = dict(zip(answers_normalized, answers_no_none))
-                for a1, a2 in combinations(answers_normalized, 2):
+                for a1, a2 in combinations(answers_no_none, 2):
                     if math_util.is_equiv_ocw(a1, a2):
-                        return revert_normalized[a1]
+                        return a1
                 return None  # no concordant answers
             
 

--- a/src/utils/llm_query_utils.py
+++ b/src/utils/llm_query_utils.py
@@ -78,7 +78,7 @@ def query_cot(
     elif backbone == "gpt4turbo":
         model_name = "gpt-4-1106-preview"
     elif backbone == "chatgpt":
-        model_name = "gpt-3.5-turbo"
+        model_name = "gpt-3.5-turbo-0613"
 
     completions = []
     cot_solution = openai.ChatCompletion.create(
@@ -103,7 +103,7 @@ def query_cot(
 
 # actual llm query function for p2c method
 def _query(  # key,
-    model_name: str = "gpt-3.5-turbo",
+    model_name: str = "gpt-3.5-turbo-0613",
     max_tokens: int = 2048,
     stop: str = None,
     messages=None,
@@ -143,7 +143,7 @@ def query_plancode(
     question: str,  # data: dict,
     plan_temperature: float = 0.0,
     code_temperature: float = 0.0,
-    backbone: str = "gpt-3.5-turbo",
+    backbone: str = "gpt-3.5-turbo-0613",
     n=1,
     seed: int = 777,
 ):
@@ -161,12 +161,12 @@ def query_plancode(
     elif backbone == "gpt4turbo":
         model_name = "gpt-4-1106-preview"
     elif backbone == "chatgpt":
-        model_name = "gpt-3.5-turbo"
+        model_name = "gpt-3.5-turbo-0613"
 
     if model_name.startswith("gpt-4"):
         # print(f'gpt-4 uses k_fewshot=5 as default (p2c fs_prompting)')
         k_fewshot = 5
-    elif model_name.startswith("gpt-3.5-turbo"):
+    elif model_name.startswith("gpt-3.5-turbo-0613"):
         # print(f'gpt-3.5 uses k_fewshot=8 as default (p2c fs-prompting)')
         k_fewshot = 8
 
@@ -235,7 +235,7 @@ def query_pal(question: str, temperature: float, backbone: str, n=1, seed=777):
     elif backbone == "gpt4turbo":
         model_name = "gpt-4-1106-preview"
     elif backbone == "chatgpt":
-        model_name = "gpt-3.5-turbo"
+        model_name = "gpt-3.5-turbo-0613"
     completions = []
     pal_solution = openai.ChatCompletion.create(
         model=model_name,
@@ -284,7 +284,7 @@ def query_selection(
     elif backbone == "gpt4turbo":
         model_name = "gpt-4-1106-preview"
     elif backbone == "chatgpt":
-        model_name = "gpt-3.5-turbo"
+        model_name = "gpt-3.5-turbo-0613"
 
     cot_pal_p2c_solution_list = [cot_solution, pal_solution, p2c_plan_code_solution]
     cot_pal_p2c_solution_list = [
@@ -325,7 +325,7 @@ def query_rims_inference(
 ) -> tuple:
     #   modif_prompt:bool=True) -> tuple:
     if backbone == "chatgpt":
-        model_name = "gpt-3.5-turbo-16k"
+        model_name = "gpt-3.5-turbo-16k-0613"
     elif backbone == "gpt4":
         model_name = "gpt-4"
     elif backbone == "gpt4turbo":

--- a/src/utils/math_util.py
+++ b/src/utils/math_util.py
@@ -12,6 +12,7 @@ except ModuleNotFoundError:
 please install sympy via pip install lm-eval[math] or pip install -e .[math]",
     )
 
+# ==== https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/minerva_math/utils.py ====
 
 class timeout:
     def __init__(self, seconds=1, error_message="Timeout"):
@@ -71,65 +72,7 @@ def is_equiv(x1: str, x2: str) -> bool:
         logging.debug(f"Failed comparing {x1} and {x2} with {e}")
         return False
 
-def numeric_equality_ocw(n1, n2, threshold=0.01):
-    '''
-    from appendix of the Minerva paper
-    '''
-    if n1 is None or n2 is None:
-        return False
-    if None in [n1, n2] or "None" in [n1, n2]:
-        return False
-    if np.isclose(n1,0) or np.isclose(n2,0) or np.isclose(n1-n2,0):
-        return np.abs(n1-n2) < threshold * (n1+n2)/2
-    else:
-        return np.isclose(n1, n2)
-
-def is_equiv_ocw(x1: str, x2: str)->bool: # to above, add numerical equivalence condition
-    """
-    x1 and x2 are normalized latex string (Minerva paper says it normalized OCW and MATH in the same way)
-    """
-    if x1 == "None":
-        x1 = None
-    if x2 == "None":
-        x2 = None
-    try:
-        with timeout(seconds=5):
-            try:
-                parsed_x1 = parse_latex(x1)
-                parsed_x2 = parse_latex(x2)
-            except (
-                sympy.parsing.latex.errors.LaTeXParsingError,
-                sympy.SympifyError,
-                TypeError,
-            ):
-                logging.debug(f"couldn't parse one of {x1} or {x2}")
-                return False
-
-            # try:
-            #     # diff = parsed_x1 - parsed_x2
-            # except TypeError:
-            #     logging.debug(f"couldn't subtract {x1} and {x2}")
-            #     return False
-
-            try:
-                if numeric_equality_ocw(parsed_x1, parsed_x2) == 0:
-                    return True
-                else:
-                    return False
-            except ValueError:
-                logging.debug(
-                    f"Had some trouble simplifying when comparing {x1} and {x2}"
-                )
-    except TimeoutError:
-        logging.debug(f"Timed out comparing {x1} and {x2}")
-        return False
-    except ImportError as e:
-        logging.error(e)
-        raise
-    except Exception as e:
-        logging.debug(f"Failed comparing {x1} and {x2} with {e}")
-        return False
-
+# these constants also used in OCW math below. do not detach this from here.
 SUBSTITUTIONS = [
     ("an ", ""),
     ("a ", ""),
@@ -224,3 +167,321 @@ def normalize_final_answer(final_answer: str) -> str:
         final_answer = final_answer.replace(",", "")
 
     return final_answer
+
+
+# ==== for OCW (from minerva appendix) ==== 
+INVALID_ANSWER = "[invalidanswer]"
+
+def is_equiv_ocw(x1: str, x2: str)->bool: # to above, add numerical equivalence condition
+    '''
+    code took from Minerva original repository and adjusted for our use
+    
+    see OCWCourses::process_results
+    https://github.com/wellecks/lm-evaluation-harness/blob/bec2172e72be4adc70e85957cc97a2fbe70c207b/lm_eval/tasks/ocw_courses.py#L153
+
+    expects x1 and x2 to be string (latex)
+    '''
+    try:
+        x1 = float(x1)
+        x2 = float(x2)
+        normalize_fn = normalize_numeric
+        is_equiv = numeric_equality_ocw
+    except ValueError as ve:
+        if "=" in x1 or "=" in x2:
+            normalize_fn = normalize_symbolic_equation
+            is_equiv =  lambda x, y: x==y
+            # answer_type = "equation" 
+        else:
+            normalize_fn = normalize_tex
+            is_equiv = is_tex_equiv
+            # answer_type = "expression"
+    
+    if INVALID_ANSWER in (x1, x2):
+        return False
+    
+    
+
+    
+def numeric_equality_ocw(n1, n2, threshold=0.01):
+    '''
+    from appendix of the Minerva paper
+    '''
+    if n1 is None or n2 is None:
+        return False
+    if "None" in [n1, n2]:
+        return False
+    if np.isclose(n1,0) or np.isclose(n2,0) or np.isclose(n1-n2,0):
+        return np.abs(n1-n2) < threshold * (n1+n2)/2
+    else:
+        return np.isclose(n1, n2)
+
+def normalize_symbolic_equation(self, s: Optional[str]):
+    if not isinstance(s, str):
+        return INVALID_ANSWER
+    if s.startswith("\\["):
+        s = s[2:]
+    if s.endswith("\\]"):
+        s = s[:-2]
+    s = s.replace("\\left(", "(")
+    s = s.replace("\\right)", ")")
+    s = s.replace("\\\\", "\\")
+    if s.startswith("$") or s.endswith("$"):
+        s = s.strip("$")
+    try:
+        maybe_expression = parse_latex(s)
+        if not isinstance(maybe_expression, sympy.core.relational.Equality):
+            # we have equation, not expression
+            return INVALID_ANSWER
+        else:
+            return maybe_expression
+    except:
+        return INVALID_ANSWER
+
+
+
+
+# ==== from Minerva code (https://github.com/wellecks/lm-evaluation-harness/blob/master/lm_eval/tasks/ocw_courses.py) ====
+def process_results(self, doc, results, params={}):
+    candidates = results[0]
+
+    assert isinstance(params, dict)
+
+    ref = doc['answer']
+
+    try:
+        float(ref)
+        normalize_fn = self.normalize_numeric
+        is_equiv = self.numeric_equality
+        answer_type = "numeric"
+    except ValueError:
+        if "=" in ref:
+            normalize_fn = self.normalize_symbolic_equation
+            is_equiv = lambda x, y: x==y
+            answer_type = "equation"
+        else:
+            normalize_fn = self.normalize_tex
+            is_equiv = self.is_tex_equiv
+            answer_type = "expression"
+
+    correct_answer = normalize_fn(ref)
+
+    if self.MAJORITY_VOTING not in params:
+        unnormalized_answer = self.get_unnormalized_answer(candidates)
+
+        model_answer = normalize_fn(unnormalized_answer)
+
+        if unnormalized_answer == self.INVALID_ANSWER:
+            acc = 0
+        elif model_answer == self.INVALID_ANSWER:
+            acc = 0
+        elif is_equiv(model_answer, correct_answer):
+            acc = 1
+        else:
+            acc = 0
+
+        pass_rate = acc
+    else:
+        answers = [
+            normalize_fn(self.get_unnormalized_answer(candidate))
+            for candidate in candidates
+            if self.get_unnormalized_answer(candidate) != self.INVALID_ANSWER
+            and normalize_fn(self.get_unnormalized_answer(candidate)) != self.INVALID_ANSWER
+        ]
+
+        acc, pass_rate, votes = self.majority_vote(
+            answers, correct_answer=correct_answer, is_equiv=is_equiv,
+        )
+        if votes:
+            model_answer = votes[0][0]
+        else:
+            model_answer = self.INVALID_ANSWER
+
+    results = {
+        "acc": acc,
+        "pass_rate": pass_rate,
+        "metadata": {
+            "selected_answer": model_answer, 
+            "unprocessed_answers": candidates,
+            "answer_type": answer_type,
+        },
+    }
+
+    if self.MAJORITY_VOTING in params:
+        results["metadata"]["votes"] = votes
+
+    return results
+
+
+
+def is_exp_equiv(self, x1: sympy.Basic, x2: sympy.Basic, time_limit=5) -> bool:
+    """
+    Determines whether two sympy expressions are equal.
+    """
+    try:
+        with timeout(seconds=time_limit):
+            try:
+                diff = x1 - x2
+            except (SympifyError, ValueError, TypeError) as e:
+                print(
+                    f"Couldn't subtract {x1} and {x2} with exception {e}"
+                )
+                return False
+
+            try:
+                if sympy.simplify(diff) == 0:
+                    return True
+                else:
+                    return False
+            except (SympifyError, ValueError, TypeError) as e:
+                print(f"Failed to simplify {x1}-{x2} with {e}")
+                return False
+    except TimeoutError as e:
+        print(f"Timed out comparing {x1} and {x2}")
+        return False
+    except Exception as e:
+        print(f"failed on unrecognized exception {e}")
+        return False
+
+def is_tex_equiv(self, x1: str, x2: str, time_limit=5) -> bool:
+    """
+    Determines whether two (ideally normalized using `normalize_text`) TeX expressions are equal.
+
+    Does so by first checking for string exact-match, then falls back on sympy-equivalence,
+    following the (Lewkowycz et al. 2022) methodology.
+    """
+    if x1 == x2:
+        # don't resort to sympy if we have full string match, post-normalization 
+        return True
+
+    parsed_x2 = self.parse_tex(x2)
+    if not parsed_x2:
+        # if our reference fails to parse into a Sympy object, 
+        # we forgo parsing + checking our generated answer.
+        return False
+    return self.is_exp_equiv(self.parse_tex(x1), parsed_x2, time_limit=time_limit)
+
+
+
+    # def numeric_equality(self, n1, n2, threshold=0.01):
+    #     if n1 is None or n2 is None:
+    #         return False
+    #     if np.isclose(n1, 0) or np.isclose(n2, 0) or np.isclose(n1 - n2, 0):
+    #         return np.abs(n1 - n2) < threshold * (n1 + n2) / 2
+    #     else:
+    #         return np.isclose(n1, n2)
+
+
+
+def normalize_numeric(self, s):
+    if s is None:
+        return None
+    for unit in [
+        "eV",
+        " \\mathrm{~kg} \\cdot \\mathrm{m} / \\mathrm{s}",
+        " kg m/s",
+        "kg*m/s",
+        "kg",
+        "m/s",
+        "m / s",
+        "m s^{-1}",
+        "\\text{ m/s}",
+        " \\mathrm{m/s}",
+        " \\text{ m/s}",
+        "g/mole",
+        "g/mol",
+        "\\mathrm{~g}",
+        "\\mathrm{~g} / \\mathrm{mol}",
+        "W",
+        "erg/s",
+        "years",
+        "year",
+        "cm",
+    ]:
+        s = s.replace(unit, "")
+        s = s.strip()
+    for maybe_unit in ["m", "s", "cm"]:
+        s = s.replace("\\mathrm{" + maybe_unit + "}", "")
+        s = s.replace("\\mathrm{~" + maybe_unit + "}", "")
+        s = s.strip()
+    s = s.strip("$")
+    try:
+        return float(eval(s))
+    except:
+        try:
+            expr = parse_latex(s)
+            if expr.is_number:
+                return float(expr)
+            return INVALID_ANSWER
+        except:
+            return INVALID_ANSWER
+        
+
+# this one from MajorityVotingMixin --> use this for get_concordant answer?
+def majority_vote(
+        self,
+        sampled_answers: List[T],
+        correct_answer: T,
+        is_equiv : Callable[[T, T], bool] = lambda x, y: x==y,
+        invalid_answer: T = None
+):
+    """
+    Performs majority voting on a list of candidate answers. 
+    Returns accuracy and pass rate checked against `correct_answer`.
+    Supports arbitrary definitions of equivalence via `is_equiv` argument.
+    
+    Arguments:
+        sampled_answers: List[T], list of sampled answers
+        correct_answer: T, ground truth.
+        is_equiv: Callable[[T, T], bool], a function that determines when two answers 
+            should be treated as equivalent. Default is T-equivalence, i.e `lambda x y: x==y`.
+        invalid_answer: T, answer that corresponds to a parsing failure from a sample. 
+            If passed as arg, no votes for invalid answer should be counted, but it should
+            count against pass_rate.
+    Returns:
+        acc: int, 0/1 for correct/incorrect
+        pass_rate: float, proportion of `sampled_answers` equivalent to `correct_answer`
+        votes: List[Tuple[T, int]], for each distinct answer, the amount of votes for that answer. 
+            Sorted by descending amount of votes, so that `elected_answer==votes[0][0]`
+    """
+    if not sampled_answers:
+        return 0, 0, []
+
+    answer_votes = {}
+
+    # we only count votes for successfully parsed answers, as we choose not
+    # to allow a model to vote for [invalidanswer] as its response.
+    # however, we do want to calculate pass_rate as a function of 
+    # total K = *num. sampled answers*.
+    if invalid_answer:
+        valid_sampled_answers = [answer for answer in sampled_answers if answer != invalid_answer]
+    else:
+        valid_sampled_answers = sampled_answers
+
+    for answer in valid_sampled_answers:
+        if answer in answer_votes: 
+            answer_votes[answer] += 1
+        else:
+            counted = False
+            for ref in answer_votes:
+                if is_equiv(answer, ref) and not counted:
+                    answer_votes[ref] += 1
+                    counted=True
+            if not counted: 
+                answer_votes[answer] = 1
+
+    votes = list(sorted(answer_votes.items(), key=lambda x: -x[1]))
+
+    elected_answer = votes[0][0]
+
+    if is_equiv(correct_answer, elected_answer):
+        acc = 1
+        pass_rate = votes[0][1] / len(sampled_answers)
+    else:
+        acc = 0
+        pass_rate = 0
+        for candidate, num_votes in answer_votes.items():
+            if is_equiv(correct_answer, candidate):
+                pass_rate = num_votes / len(sampled_answers)
+                break
+
+    return acc, pass_rate, votes

--- a/src/utils/math_util.py
+++ b/src/utils/math_util.py
@@ -188,10 +188,11 @@ def is_equiv_ocw(x1: str, x2: str)->bool: # to above, add numerical equivalence 
     x1 = str(x1)
     x2 = str(x2)
     try:
-        float(x1)
-        float(x2)
+        # original code checks if the reference answer is float() castable, but my case, x1, x2 are not certainly numberic or numeric with units --> normalize_numeric() to remove units and then float cast  
         normalize_fn = normalize_numeric
         _is_equiv = numeric_equality_ocw
+        float(normalize_fn(x1))
+        float(normalize_fn(x2))
         # answer_type = "numeric"
     except ValueError as ve:
         if "=" in x1 or "=" in x2:
@@ -214,12 +215,16 @@ def numeric_equality_ocw(n1, n2, threshold=0.01):
     '''
     from appendix of the Minerva paper
     '''
+    # this assumes n1, n2 are numerics. so cast it into float
+    n1, n2 = map(float, [n1, n2])
     if n1 is None or n2 is None:
         return False
     if "None" in [n1, n2]:
         return False
+    if n1 == n2: # exact match covered here
+        return n1==n2 
     if np.isclose(n1,0) or np.isclose(n2,0) or np.isclose(n1-n2,0):
-        return np.abs(n1-n2) < threshold * (n1+n2)/2
+        return np.abs(n1-n2) < threshold * np.abs(n1+n2)/2 # original code cannot cover negative numbers, so added np.abs to threshold condition to cover it.
     else:
         return np.isclose(n1, n2)
 


### PR DESCRIPTION
#28 을 해결하는 커밋: 
ocw 첫번째 run을 evaluation했을 때, 모든 답이 0점처리되며 majority vote 처리가 제대로 되지 않았었던 것을 고쳤다. 

ocw chatgpt out을 기반으로 수행했고 디버깅 전 후의 majority vote 의 실행 결과는 다음 [diffchecker link](https://www.diffchecker.com/xJZA7Hgt/)에 소상히 나와있다.

[minerva author code](https://github.com/wellecks/lm-evaluation-harness/blob/bec2172e72be4adc70e85957cc97a2fbe70c207b/lm_eval/tasks/ocw_courses.py#L153)를 그대로 가져왔을 때 exact numeric match와 음수를 처리하지 못하던 것을 추가로 보강하였고 버그가 없음을 확인했다.

버그성 인풋에 대한 확인 코드와 아웃풋을 아래 첨부한다.

```python
# debug original equivalence function !

from dbg_ocw_eq import get_concordant_answer
from pprint import pprint 
samples = [
    ([5.9, 0.0, 0.0], 0), 
    ([2.0, -1.9999999999999996, -1.9999999999999996], -1.9999999999999996), 
    ([27.0, 0.0, 0.0], 0), 
    ([0.0, 0.0, 0.0], 0), 
]


suspected = [
    ([0.0249, 0.021934810768762875, 0.021500429404793922], '__'),
    ([299.7, 299.58058717795086, 277.74], '__'),
    ([-1, -1, 0], -1),
    ([-1.5, None, None,], -1.5)
]


correctly_done = [
    ([8.005204, 8.0052, 4.0015], 8.0052),
    ([1.3, 1.3, 1.3], 1.3),
    ([None, 1.8, 1.8], 1.8),
    ([None, -1, None], -1), 
]

print("\nsamples")
pprint(samples)
for answers, expected in samples:
    print(get_concordant_answer(answers, dataset_type="ocw"), expected)

# all passed
print("\nsuspected")
pprint(suspected)
for answers, expected in suspected:
    print(get_concordant_answer(answers, dataset_type="ocw"), expected)  

print("\ncorrectly_done")
pprint(correctly_done)
for answers, expected in correctly_done:
    print(get_concordant_answer(answers, dataset_type="ocw"), expected)
```

```python
# output
samples
[([5.9, 0.0, 0.0], 0),
 ([2.0, -1.9999999999999996, -1.9999999999999996], -1.9999999999999996),
 ([27.0, 0.0, 0.0], 0),
 ([0.0, 0.0, 0.0], 0)]
0.0 0
-1.9999999999999996 -1.9999999999999996
0.0 0
0.0 0

suspected
[([0.0249, 0.021934810768762875, 0.021500429404793922], '__'),
 ([299.7, 299.58058717795086, 277.74], '__'),
 ([-1, -1, 0], -1),
 ([-1.5, None, None], -1.5)]
None __
None __
-1 -1
-1.5 -1.5

correctly_done
[([8.005204, 8.0052, 4.0015], 8.0052),
 ([1.3, 1.3, 1.3], 1.3),
 ([None, 1.8, 1.8], 1.8),
 ([None, -1, None], -1)]
8.005204 8.0052
1.3 1.3
1.8 1.8
-1 -1
```

